### PR TITLE
Standardize README: badges, Conda install, License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # AcidGenomes
 
-![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
-[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](https://bioconda.github.io/recipes/r-acidgenomes/README.html)
+[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/r-acidgenomes/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
 
 Toolkit for downloading and processing genome annotations.
 
@@ -36,7 +35,7 @@ R
 ```
 
 [bioconda]: https://bioconda.github.io/
-[conda]: https://docs.conda.io/en/latest/
+[conda]: https://docs.conda.io/
 [r]: https://www.r-project.org/
 
 


### PR DESCRIPTION
- Fix badge order: Bioconda badge before lifecycle badge (canonical order)
- Remove `?style=flat` from Bioconda badge URL
- Fix `[conda]` link: remove `/en/latest/` suffix, use `https://docs.conda.io/`