### PR TITLE
Add tests/testthat/_problems/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .Rhistory
 .Rproj.user
 docs/
+tests/testthat/_problems/


### PR DESCRIPTION
The `_problems/` directory is generated by testthat's `check` reporter and should not be tracked in git.